### PR TITLE
エラーメッセージの日本語化の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.5)
       actionpack (= 6.0.5)
       activesupport (= 6.0.5)
@@ -328,6 +331,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,11 +13,11 @@ class Item < ApplicationRecord
   with_options presence: true do
     validates :name
     validates :profile
-    validates :category_genre_id, numericality: { other_than: 1, message: 'が未選択では登録できません' }
-    validates :status_genre_id, numericality: { other_than: 1, message: 'が未選択では登録できません' }
-    validates :send_price_genre_id, numericality: { other_than: 1, message: 'が未選択では登録できません' }
-    validates :place_genre_id, numericality: { other_than: 1, message: 'が未選択では登録できません' }
-    validates :scheduled_day_genre_id, numericality: { other_than: 1, message: 'が未選択では登録できません' }
+    validates :category_genre_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
+    validates :status_genre_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
+    validates :send_price_genre_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
+    validates :place_genre_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
+    validates :scheduled_day_genre_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
     validates :image
     validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, only_integer: true }
   end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -4,7 +4,7 @@ class OrderAddress
 
   with_options presence: true do
     validates :post_code
-    validates :place_id, numericality: { other_than: 1 }
+    validates :place_id, numericality: { other_than: 1, message: 'は未選択では登録できません' }
     validates :town
     validates :number
     validates :phone_number
@@ -13,8 +13,8 @@ class OrderAddress
     validates :item_id
   end
   validates :post_code,
-            format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'Post code is invalid. Enter it as follows (e.g. 123-4567)' }
-  validates :phone_number, format: { with: /\A\d{10}$|^\d{11}\z/, message: 'PhoneNumber must be 10or11 digit Half-width numbers' }
+            format: { with: /\A[0-9]{3}-[0-9]{4}\z/ }
+  validates :phone_number, format: { with: /\A\d{10}$|^\d{11}\z/ }
 
   def save
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,11 +9,11 @@ class User < ApplicationRecord
 
   with_options presence: true do
     validates :name
-    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: '全角文字を使用してください' }
-    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: '全角文字を使用してください' }
-    validates :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: '全角カタカナを使用してください' }
-    validates :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: '全角カタカナを使用してください' }
+    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ }
+    validates :first_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
+    validates :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/ }
     validates :birthday
-    validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: '英数字文字6以上' }
+    validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Furima37671
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,34 @@
+ja: 
+  activerecord:
+    attributes:
+     user:
+      name: ニックネーム
+      first_name: 苗字
+      last_name: 名前
+      first_name_kana: 苗字（カナ）
+      last_name_kana: 名前（カナ）
+      birthday: 誕生日
+
+     item:
+      name: 商品名
+      profile: 商品の説明
+      category_genre_id: カテゴリー 
+      status_genre_id: 商品の状態
+      place_genre_id: 発送元の地域
+      send_price_genre_id: 配送料の負担
+      scheduled_day_genre_id: 発送までの日数
+      price: 販売価格
+      image: 商品画像
+
+  activemodel:
+    attributes:
+     order_address:
+         post_code: 郵便番号
+         place_id: 都道府県
+         town: 市区町村
+         number: 番地
+         phone_number: 電話番号
+         token: クレジットカード情報
+
+
+

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -30,27 +30,27 @@ RSpec.describe Item, type: :model do
         it 'カテゴリーが未選択では登録できない' do
           @item.category_genre_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include('Category genre が未選択では登録できません')
+          expect(@item.errors.full_messages).to include('Category genre は未選択では登録できません')
         end
         it '商品の状態が未選択では登録できない' do
           @item.status_genre_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include('Status genre が未選択では登録できません')
+          expect(@item.errors.full_messages).to include('Status genre は未選択では登録できません')
         end
         it '配送料の負担が未選択では登録できない' do
           @item.send_price_genre_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include('Send price genre が未選択では登録できません')
+          expect(@item.errors.full_messages).to include('Send price genre は未選択では登録できません')
         end
         it '発送元の地域が未選択では登録できない' do
           @item.place_genre_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include('Place genre が未選択では登録できません')
+          expect(@item.errors.full_messages).to include('Place genre は未選択では登録できません')
         end
         it '発送までの発送までの日数が未選択では登録できない' do
           @item.scheduled_day_genre_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include('Scheduled day genre が未選択では登録できません')
+          expect(@item.errors.full_messages).to include('Scheduled day genre は未選択では登録できません')
         end
         it '販売価格が空では登録できない' do
           @item.price = ''

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -42,17 +42,17 @@ RSpec.describe OrderAddress, type: :model do
     it '郵便番号は半角文字以外では登録できない' do
       @order_address.post_code = '１２３-４５６７'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Post code Post code is invalid. Enter it as follows (e.g. 123-4567)')
+      expect(@order_address.errors.full_messages).to include('Post code is invalid')
     end
     it '郵便番号はハイフンなしでは登録できない' do
       @order_address.post_code = '1234567'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Post code Post code is invalid. Enter it as follows (e.g. 123-4567)')
+      expect(@order_address.errors.full_messages).to include('Post code is invalid')
     end
     it '都道府県が空では登録できない' do
       @order_address.place_id = '1'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Place must be other than 1')
+      expect(@order_address.errors.full_messages).to include('Place は未選択では登録できません')
     end
     it '市区町村が未選択では登録できない' do
       @order_address.town = ''
@@ -72,22 +72,22 @@ RSpec.describe OrderAddress, type: :model do
     it '電話番号は9桁以下では登録できない' do
       @order_address.phone_number = '12345678'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Phone number PhoneNumber must be 10or11 digit Half-width numbers')
+      expect(@order_address.errors.full_messages).to include('Phone number is invalid')
     end
     it '電話番号は12桁以上では登録できない' do
       @order_address.phone_number = '123456789012'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Phone number PhoneNumber must be 10or11 digit Half-width numbers')
+      expect(@order_address.errors.full_messages).to include('Phone number is invalid')
     end
     it '電話番号は半角数値以外では登録できない' do
       @order_address.phone_number = '０８０６０９８２２３５'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Phone number PhoneNumber must be 10or11 digit Half-width numbers')
+      expect(@order_address.errors.full_messages).to include('Phone number is invalid')
     end
     it '電話番号はハイフンがあると登録できない' do
       @order_address.phone_number = '080-6098-2235'
       @order_address.valid?
-      expect(@order_address.errors.full_messages).to include('Phone number PhoneNumber must be 10or11 digit Half-width numbers')
+      expect(@order_address.errors.full_messages).to include('Phone number is invalid')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,19 +36,19 @@ RSpec.describe User, type: :model do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password 英数字文字6以上')
+        expect(@user.errors.full_messages).to include('Password is invalid')
       end
       it '数字のみのパスワードでは登録できない' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password 英数字文字6以上')
+        expect(@user.errors.full_messages).to include('Password is invalid')
       end
       it '全角文字を含むパスワードでは登録できない' do
         @user.password = '12345ａ'
         @user.password_confirmation = '12345ａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password 英数字文字6以上')
+        expect(@user.errors.full_messages).to include('Password is invalid')
       end
       it 'first_nameが空では登録できない' do
         @user.first_name = ''
@@ -73,22 +73,22 @@ RSpec.describe User, type: :model do
       it 'first_nameに半角文字が含まれていると登録できない' do
         @user.first_name = 'abe'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name 全角文字を使用してください')
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
       it 'last_name半角文字が含まれていると登録できない' do
         @user.last_name = 'ryo'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name 全角文字を使用してください')
+        expect(@user.errors.full_messages).to include('Last name is invalid')
       end
       it 'first_name_kanaにカタカナ以外の文字（平仮名・漢字・英数字・記号）が含まれていると登録できない' do
         @user.first_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana 全角カタカナを使用してください')
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
       it 'last_name_kanaにカタカナ以外の文字（平仮名・漢字・英数字・記号）が含まれていると登録できない' do
         @user.last_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana 全角カタカナを使用してください')
+        expect(@user.errors.full_messages).to include('Last name kana is invalid')
       end
       it '重複したemailが存在する場合は登録できない' do
         @user.save


### PR DESCRIPTION
# What
エラーメッセージの日本語化の実装

# Why
ユーザー新規登録時・商品出品時・商品購入時における
エラーメッセージを日本語で表示するため
